### PR TITLE
HM #1 - Add staff entity parsing

### DIFF
--- a/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
@@ -14,12 +14,12 @@ namespace HoNAvatarManager.Core.Parsers.Hero
 
         public override void SetEntity(string heroDirectoryPath, string avatarKey)
         {
-            SetEntityInternal(heroDirectoryPath, avatarKey, "hero", "hero");
+            SetEntityInternal(heroDirectoryPath, avatarKey, "hero");
         }
 
-        protected void SetEntityInternal(string heroDirectoryPath, string avatarKey, string entityName, string entityFileName)
+        protected void SetEntityInternal(string heroDirectoryPath, string avatarKey, string entityName)
         {
-            var entityFilePath = Path.Combine(heroDirectoryPath, $"{entityFileName}.entity");
+            var entityFilePath = Path.Combine(heroDirectoryPath, $"{entityName}.entity");
 
             if (!File.Exists(entityFilePath))
             {

--- a/src/HoNAvatarManager.Core/Parsers/Hero/StaffEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Hero/StaffEntityParser.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using System.Linq;
+using HoNAvatarManager.Core.Extensions;
+
+namespace HoNAvatarManager.Core.Parsers.Hero
+{
+    internal class StaffEntityParser : EntityParser
+    {
+        public StaffEntityParser(XmlManager xmlManager) : base(xmlManager)
+        {
+
+        }
+
+        public override void SetEntity(string heroDirectoryPath, string avatarKey)
+        {
+            SetEntityInternal(heroDirectoryPath, avatarKey, "state");
+        }
+
+        protected void SetEntityInternal(string heroDirectoryPath, string avatarKey, string entityName)
+        {
+            var entityFiles = Directory.EnumerateFiles(heroDirectoryPath, "state_*_ult_boost.entity");
+
+            foreach (var entityFilePath in entityFiles)
+            {
+                var entityXml = _xmlManager.GetXmlDocument(entityFilePath);
+
+                var entityElement = entityXml.QuerySelector(entityName);
+                var entityAvatarElements = entityElement.QuerySelectorAll("altavatar");
+                var entityAvatarElement = entityAvatarElements.FirstOrDefault(a => a.HasKey(avatarKey));
+
+                if (entityAvatarElement == null)
+                {
+                    return;
+                }
+
+                entityElement.SetElementAttributes(entityAvatarElement).SetElementChilds(entityAvatarElement);
+
+                entityXml.SaveXml(entityFilePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1 

* Add `staff_%heroname%_ult_boost.entity` file parsing - now SotM effects should correctly display for all avatars.