### PR TITLE
HM #12 - Fix throwback avatars parsing

### DIFF
--- a/src/HoNAvatarManager.Core/AvatarManager.cs
+++ b/src/HoNAvatarManager.Core/AvatarManager.cs
@@ -54,8 +54,6 @@ namespace HoNAvatarManager.Core
                     throw new Exception($"Avatar {avatar} not found for hero {hero}.");
                 }
 
-                var avatarDirectoryPath = GetAvatarDirectory(rootResourcesDirectory, heroResourcesName, avatarElement);
-
                 foreach(var parser in EntityParser.GetRegisteredEntityParsers(_xmlManager))
                 {
                     parser.SetEntity(heroDirectoryPath, avatarKey);
@@ -141,14 +139,6 @@ namespace HoNAvatarManager.Core
             return GlobalResources.HeroAvatarMapping.SingleOrDefault(x => string.Equals(x.Hero, hero, StringComparison.InvariantCultureIgnoreCase))?
                 .AvatarInfo.SingleOrDefault(x => string.Equals(x.AvatarName, avatarFriendlyName, StringComparison.InvariantCultureIgnoreCase))?
                 .ResourceName ?? avatarFriendlyName;
-        }
-
-        private string GetAvatarDirectory(string extractedHeroResourcesDirectory, string heroResourcesName, IElement avatarElement)
-        {
-            var avatarDirectoryName = avatarElement.Attributes["model"].Value.Split('/')[0];
-            var avatarDirectoryPath = Path.Combine(extractedHeroResourcesDirectory, "heroes", heroResourcesName, avatarDirectoryName);
-
-            return avatarDirectoryPath;
         }
 
         private string GetHeroResourcesName(string hero)

--- a/src/HoNAvatarManager.Core/Extensions/AvatarKeyExtensions.cs
+++ b/src/HoNAvatarManager.Core/Extensions/AvatarKeyExtensions.cs
@@ -11,5 +11,11 @@ namespace HoNAvatarManager.Core.Extensions
 
             return match.Success ? match.Groups["key"].Value : avatarKey;
         }
+
+        public static bool IsClassicAvatar(this string avatarKey)
+        {
+            var classicRegex = new Regex(@".*\.?[Cc]lassic");
+            return classicRegex.IsMatch(avatarKey);
+        }
     }
 }

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityBaseEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityBaseEntityParser.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using HoNAvatarManager.Core.Extensions;
 
@@ -14,6 +13,11 @@ namespace HoNAvatarManager.Core.Parsers.Ability
 
         protected void SetEntityInternal(string heroDirectoryPath, string avatarKey, string entityName)
         {
+            if (avatarKey.IsClassicAvatar())
+            {
+                return;
+            }
+
             var heroAbilityDirectories = Directory.EnumerateDirectories(heroDirectoryPath, "ability_*");
 
             foreach (var heroAbilityDirectory in heroAbilityDirectories)

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
@@ -14,6 +14,11 @@ namespace HoNAvatarManager.Core.Parsers.Ability
 
         public override void SetEntity(string heroDirectoryPath, string avatarKey)
         {
+            if (avatarKey.IsClassicAvatar())
+            {
+                return;
+            }
+
             var avatarDirectoryPath = GetAvatarDirectory(heroDirectoryPath, avatarKey);
             var heroAbilityDirectories = Directory.EnumerateDirectories(heroDirectoryPath, "ability_*").Select(d => new DirectoryInfo(d));
             var avatarAbilityDirectories = Directory.EnumerateDirectories(avatarDirectoryPath, "ability_*").Select(d => new DirectoryInfo(d));


### PR DESCRIPTION
Fixes #12 

* Fixed throwback avatars parsing - it should now correctly parse `hero` and `staff` `.entity` files.