### PR TITLE
HM #18 - Add platform specific build properties

### DIFF
--- a/src/HoNAvatarManager.Core/AvatarManager.cs
+++ b/src/HoNAvatarManager.Core/AvatarManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using AngleSharp.Dom;
 using HoNAvatarManager.Core.Parsers;
 
 namespace HoNAvatarManager.Core
@@ -17,6 +16,13 @@ namespace HoNAvatarManager.Core
 
         public AvatarManager()
         {
+#if Windows
+            if (!PlatformSpecific.Windows.Utilities.IsAdministrator())
+            {
+                throw new UnauthorizedAccessException("Please run HoN Avatar Manager as Administrator.");
+            }
+#endif
+
             _configurationManager = new ConfigurationManager("appsettings.json");
             _appConfiguration = _configurationManager.GetAppConfiguration();
 
@@ -54,7 +60,7 @@ namespace HoNAvatarManager.Core
                     throw new Exception($"Avatar {avatar} not found for hero {hero}.");
                 }
 
-                foreach(var parser in EntityParser.GetRegisteredEntityParsers(_xmlManager))
+                foreach (var parser in EntityParser.GetRegisteredEntityParsers(_xmlManager))
                 {
                     parser.SetEntity(heroDirectoryPath, avatarKey);
                 }
@@ -65,14 +71,6 @@ namespace HoNAvatarManager.Core
                 _resourcesManager.PackHeroResources(heroResourcesDirectory, heroResourcesS2ZFilePath);
 
                 File.Copy(heroResourcesS2ZFilePath, Path.Combine(_appConfiguration.HoNPath, "game", heroResourcesS2ZFileName), true);
-            }
-            catch (UnauthorizedAccessException ex)
-            {
-                throw new UnauthorizedAccessException("Please run PowerShell Core as Administrator.", ex);
-            }
-            catch
-            {
-                throw;
             }
             finally
             {

--- a/src/HoNAvatarManager.Core/HoNAvatarManager.Core.csproj
+++ b/src/HoNAvatarManager.Core/HoNAvatarManager.Core.csproj
@@ -2,11 +2,27 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsOSX)'=='true'">
+    <DefineConstants>OSX</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.14.0" />
     <PackageReference Include="AngleSharp.Xml" Version="0.14.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/HoNAvatarManager.Core/PlatformSpecific/Windows/Utilities.cs
+++ b/src/HoNAvatarManager.Core/PlatformSpecific/Windows/Utilities.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Principal;
+
+namespace HoNAvatarManager.Core.PlatformSpecific.Windows
+{
+    internal static class Utilities
+    {
+        public static bool IsAdministrator()
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #18 

* Add `PlatformSpecific.Windows.Utilities` to store Windows-specific utilities.
* Add early administrator check - now the program will fail at the start if not launched as Administrator rather than at the file copy time.