### PR TITLE
HM #22 - Add missing avatar names part 1

### DIFF
--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
@@ -28,7 +28,7 @@ namespace HoNAvatarManager.PowerShell.Completers
 
             return heroAvatars?.AvatarInfo
                 .Where(avatar => avatar.AvatarName.StartsWith(wordToComplete.Trim('"'), StringComparison.InvariantCultureIgnoreCase))
-                .Select(avatar => new CompletionResult($"\"{avatar.AvatarName}\""));
+                .Select(avatar => new CompletionResult($"\"{avatar.AvatarName}\"", avatar.AvatarName, CompletionResultType.ParameterValue, avatar.AvatarName));
         }
     }
 }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
@@ -27,7 +27,7 @@ namespace HoNAvatarManager.PowerShell.Completers
             var heroAvatars = GlobalResources.HeroAvatarMapping.FirstOrDefault(x => x.Hero.Equals(hero, StringComparison.InvariantCultureIgnoreCase));
 
             return heroAvatars?.AvatarInfo
-                .Where(avatar => avatar.AvatarName.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
+                .Where(avatar => avatar.AvatarName.StartsWith(wordToComplete.Trim('"'), StringComparison.InvariantCultureIgnoreCase))
                 .Select(avatar => new CompletionResult($"\"{avatar.AvatarName}\""));
         }
     }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
@@ -28,7 +28,6 @@ namespace HoNAvatarManager.PowerShell.Completers
 
             return heroAvatars?.AvatarInfo
                 .Where(avatar => avatar.AvatarName.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
-                .OrderBy(avatar => avatar.AvatarName)
                 .Select(avatar => new CompletionResult($"\"{avatar.AvatarName}\""));
         }
     }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroAvatarArgumentCompleter.cs
@@ -24,11 +24,12 @@ namespace HoNAvatarManager.PowerShell.Completers
 
             var hero = (string)fakeBoundParameters["Hero"];
 
-            var avatarManager = new AvatarManager();
+            var heroAvatars = GlobalResources.HeroAvatarMapping.FirstOrDefault(x => x.Hero.Equals(hero, StringComparison.InvariantCultureIgnoreCase));
 
-            return avatarManager.GetHeroAvatars(hero)
-                .Where(avatar => avatar.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
-                .Select(avatar => new CompletionResult($"\"{avatarManager.GetHeroAvatarFriendlyName(hero, avatar)}\""));
+            return heroAvatars?.AvatarInfo
+                .Where(avatar => avatar.AvatarName.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(avatar => avatar.AvatarName)
+                .Select(avatar => new CompletionResult($"\"{avatar.AvatarName}\""));
         }
     }
 }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
@@ -18,7 +18,7 @@ namespace HoNAvatarManager.PowerShell.Completers
             IDictionary fakeBoundParameters)
         {
             return GlobalResources.HeroNames
-                .Where(name => name.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
+                .Where(name => name.StartsWith(wordToComplete.Trim('"'), StringComparison.InvariantCultureIgnoreCase))
                 .OrderBy(name => name)
                 .Select(name => new CompletionResult($"\"{name}\""));
         }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
@@ -19,6 +19,7 @@ namespace HoNAvatarManager.PowerShell.Completers
         {
             return GlobalResources.HeroNames
                 .Where(name => name.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase))
+                .OrderBy(name => name)
                 .Select(name => new CompletionResult($"\"{name}\""));
         }
     }

--- a/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
+++ b/src/HoNAvatarManagement.PowerShell/Completers/HeroNameArgumentCompleter.cs
@@ -20,7 +20,7 @@ namespace HoNAvatarManager.PowerShell.Completers
             return GlobalResources.HeroNames
                 .Where(name => name.StartsWith(wordToComplete.Trim('"'), StringComparison.InvariantCultureIgnoreCase))
                 .OrderBy(name => name)
-                .Select(name => new CompletionResult($"\"{name}\""));
+                .Select(name => new CompletionResult($"\"{name}\"", name, CompletionResultType.ParameterValue, name));
         }
     }
 }

--- a/src/HoNAvatarManagement.PowerShell/HoNAvatarManager.psd1
+++ b/src/HoNAvatarManagement.PowerShell/HoNAvatarManager.psd1
@@ -12,7 +12,7 @@
 RootModule = 'HoNAvatarManager.PowerShell.dll'
 
 # Version number of this module.
-ModuleVersion = '0.1.5'
+ModuleVersion = '0.1.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/HoNAvatarManager.Core/AvatarManager.cs
+++ b/src/HoNAvatarManager.Core/AvatarManager.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using HoNAvatarManager.Core.Exceptions;
+using HoNAvatarManager.Core.Helpers;
 using HoNAvatarManager.Core.Logging;
 using HoNAvatarManager.Core.Parsers;
 
@@ -29,7 +31,7 @@ namespace HoNAvatarManager.Core
 
             if (!Directory.Exists(_appConfiguration.HoNPath))
             {
-                throw new DirectoryNotFoundException($"HoN directory not found at {_appConfiguration.HoNPath}.");
+                throw ThrowHelper.DirectoryNotFoundException($"HoN directory not found at {_appConfiguration.HoNPath}.");
             }
 
             _resourcesManager = new ResourcesManager(_appConfiguration);
@@ -58,7 +60,7 @@ namespace HoNAvatarManager.Core
 
                 if (avatarElement == null)
                 {
-                    throw new Exception($"Avatar {avatar} not found for hero {hero}.");
+                    throw ThrowHelper.AvatarNotFound($"Avatar {avatar} not found for hero {hero}.", avatar);
                 }
 
                 foreach (var parser in EntityParser.GetRegisteredEntityParsers(_xmlManager))
@@ -103,7 +105,7 @@ namespace HoNAvatarManager.Core
 
                 if (avatarElement == null)
                 {
-                    throw new Exception($"Avatar {avatar} not found for hero {hero}.");
+                    throw ThrowHelper.AvatarNotFound($"Avatar {avatar} not found for hero {hero}.", avatar);
                 }
 
                 foreach (var parser in EntityParser.GetRegisteredEntityParsers(_xmlManager))
@@ -182,7 +184,7 @@ namespace HoNAvatarManager.Core
                 return heroEntityPath;
             }
 
-            throw new FileNotFoundException("Cannot find hero.entity file.", heroEntityPath);
+            throw ThrowHelper.FileNotFoundException("Cannot find hero.entity file.", heroEntityPath);
         }
 
         private string GetHeroAvatarKey(string hero, string avatarFriendlyName)
@@ -198,7 +200,7 @@ namespace HoNAvatarManager.Core
 
             if (key == null)
             {
-                throw new KeyNotFoundException($"Hero {hero} not found.");
+                throw ThrowHelper.KeyNotFoundException($"Hero {hero} not found.");
             }
 
             return GlobalResources.HeroResourcesMapping[key];

--- a/src/HoNAvatarManager.Core/Exceptions/AvatarNotFoundException.cs
+++ b/src/HoNAvatarManager.Core/Exceptions/AvatarNotFoundException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace HoNAvatarManager.Core.Exceptions
+{
+    [Serializable()]
+    public class AvatarNotFoundException : Exception, ISerializable
+    {
+        public string Avatar { get; }
+
+        public AvatarNotFoundException(string message, string avatar) : base(message) 
+        {
+            Avatar = avatar;
+        }
+
+        public AvatarNotFoundException(string message, string avatar, System.Exception inner) : base(message, inner) 
+        {
+            Avatar = avatar;
+        }
+
+        public AvatarNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context) 
+        {
+            
+        }
+    }
+}

--- a/src/HoNAvatarManager.Core/Extensions/IElementExtensions.cs
+++ b/src/HoNAvatarManager.Core/Extensions/IElementExtensions.cs
@@ -18,11 +18,11 @@ namespace HoNAvatarManager.Core.Extensions
             return string.Equals(elementKey.ParseAvatarKey(), key, StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public static IElement SetElementAttributes(this IElement thisElement, IElement otherElement)
+        public static IElement SetElementAttributes(this IElement thisElement, IElement otherElement, params string[] skipAttributes)
         {
             var otherElementAttributes = otherElement.Attributes.Where(a => a.Name != "key");
 
-            foreach (var attribute in otherElementAttributes)
+            foreach (var attribute in otherElementAttributes.Where(attribute => !skipAttributes.Contains(attribute.Name)))
             {
                 thisElement.SetAttribute(attribute.Name, attribute.Value);
             }

--- a/src/HoNAvatarManager.Core/Helpers/ThrowHelper.cs
+++ b/src/HoNAvatarManager.Core/Helpers/ThrowHelper.cs
@@ -1,0 +1,41 @@
+﻿using HoNAvatarManager.Core.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace HoNAvatarManager.Core.Helpers
+{
+    internal static class ThrowHelper
+    {
+        public static DirectoryNotFoundException DirectoryNotFoundException(string message)
+        {
+            return new DirectoryNotFoundException(AppendSubmitIssue(message));
+        }
+
+        public static AvatarNotFoundException AvatarNotFound(string message, string avatar)
+        {
+            return new AvatarNotFoundException(AppendSubmitIssue(message), avatar);
+        }
+
+        public static FileNotFoundException FileNotFoundException(string message)
+        {
+            return new FileNotFoundException(AppendSubmitIssue(message));
+        }
+
+        public static FileNotFoundException FileNotFoundException(string message, string fileName)
+        {
+            return new FileNotFoundException(AppendSubmitIssue(message), fileName);
+        }
+
+        public static KeyNotFoundException KeyNotFoundException(string message)
+        {
+            return new KeyNotFoundException(AppendSubmitIssue(message));
+        }
+
+        private static string AppendSubmitIssue(string message)
+        {
+            return message + " Submit an issue: https://github.com/Semptra/HoNAvatarManager/issues/new";
+        }
+    }
+}

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using HoNAvatarManager.Core.Extensions;
-using HoNAvatarManager.Core.Helpers;
 
 namespace HoNAvatarManager.Core.Parsers.Ability
 {
@@ -38,62 +36,6 @@ namespace HoNAvatarManager.Core.Parsers.Ability
                     avatarAbilityFile.CopyTo(newAvatarAbilityFilePath.FullName, true);
                 }
             }
-        }
-
-        private string GetAvatarDirectory(string heroDirectoryPath, string avatarKey)
-        {
-            var heroDirectories = Directory.EnumerateDirectories(heroDirectoryPath).Select(d => new DirectoryInfo(d));
-            var avatarDirectory = heroDirectories.FirstOrDefault(d => string.Equals(d.Name, avatarKey, StringComparison.InvariantCultureIgnoreCase));
-
-            if (avatarDirectory != null)
-            {
-                return avatarDirectory.FullName;
-            }
-
-            var parsedAvatarKey = avatarKey.ParseAvatarKey();
-            avatarDirectory = heroDirectories.FirstOrDefault(d => string.Equals(d.Name, parsedAvatarKey, StringComparison.InvariantCultureIgnoreCase));
-
-            if (avatarDirectory != null)
-            {
-                return avatarDirectory.FullName;
-            }
-
-            var entityFilePath = GetHeroEntityPath(heroDirectoryPath);
-            var entityXml = _xmlManager.GetXmlDocument(entityFilePath);
-
-            var entityElement = entityXml.QuerySelector("hero");
-            var entityAvatarElements = entityElement.QuerySelectorAll("altavatar");
-            var entityAvatarElement = entityAvatarElements.FirstOrDefault(a => a.HasKey(avatarKey));
-
-            var modelDirectory = entityAvatarElement.GetAttribute("model").Split("/").First();
-            var avatarDirectoryPath = Path.Combine(heroDirectoryPath, modelDirectory);
-
-            if (Directory.Exists(avatarDirectoryPath))
-            {
-                return avatarDirectoryPath;
-            }
-
-            throw ThrowHelper.DirectoryNotFoundException($"Directory not found for avatar {avatarKey}.");
-        }
-
-        protected string GetHeroEntityPath(string heroDirectoryPath)
-        {
-            var heroEntityFilePath = Path.Combine(heroDirectoryPath, $"hero.entity");
-
-            if (File.Exists(heroEntityFilePath))
-            {
-                return heroEntityFilePath;
-            }
-
-            var heroDirectoryPathInfo = new DirectoryInfo(heroDirectoryPath);
-            var heroNameEntityFilePath = Path.Combine(heroDirectoryPath, $"{heroDirectoryPathInfo.Name}.entity");
-
-            if (File.Exists(heroNameEntityFilePath))
-            {
-                return heroNameEntityFilePath;
-            }
-
-            throw ThrowHelper.FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
         }
     }
 }

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using HoNAvatarManager.Core.Extensions;
+using HoNAvatarManager.Core.Helpers;
 
 namespace HoNAvatarManager.Core.Parsers.Ability
 {
@@ -72,7 +73,7 @@ namespace HoNAvatarManager.Core.Parsers.Ability
                 return avatarDirectoryPath;
             }
 
-            throw new DirectoryNotFoundException($"Directory not found for avatar {avatarKey}.");
+            throw ThrowHelper.DirectoryNotFoundException($"Directory not found for avatar {avatarKey}.");
         }
 
         protected string GetHeroEntityPath(string heroDirectoryPath)
@@ -92,7 +93,7 @@ namespace HoNAvatarManager.Core.Parsers.Ability
                 return heroNameEntityFilePath;
             }
 
-            throw new FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
+            throw ThrowHelper.FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
         }
     }
 }

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
@@ -25,7 +25,6 @@ namespace HoNAvatarManager.Core.Parsers.Ability
 
             foreach (var avatarAbilityDirectory in avatarAbilityDirectories)
             {
-                var heroAbilityDirectory = heroAbilityDirectories.Single(d => d.Name == avatarAbilityDirectory.Name);
                 var avatarAbilityFiles = avatarAbilityDirectory.EnumerateFiles("*", SearchOption.AllDirectories);
 
                 foreach (var avatarAbilityFile in avatarAbilityFiles)

--- a/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Ability/AbilityFilesEntityParser.cs
@@ -57,7 +57,42 @@ namespace HoNAvatarManager.Core.Parsers.Ability
                 return avatarDirectory.FullName;
             }
 
+            var entityFilePath = GetHeroEntityPath(heroDirectoryPath);
+            var entityXml = _xmlManager.GetXmlDocument(entityFilePath);
+
+            var entityElement = entityXml.QuerySelector("hero");
+            var entityAvatarElements = entityElement.QuerySelectorAll("altavatar");
+            var entityAvatarElement = entityAvatarElements.FirstOrDefault(a => a.HasKey(avatarKey));
+
+            var modelDirectory = entityAvatarElement.GetAttribute("model").Split("/").First();
+            var avatarDirectoryPath = Path.Combine(heroDirectoryPath, modelDirectory);
+
+            if (Directory.Exists(avatarDirectoryPath))
+            {
+                return avatarDirectoryPath;
+            }
+
             throw new DirectoryNotFoundException($"Directory not found for avatar {avatarKey}.");
+        }
+
+        protected string GetHeroEntityPath(string heroDirectoryPath)
+        {
+            var heroEntityFilePath = Path.Combine(heroDirectoryPath, $"hero.entity");
+
+            if (File.Exists(heroEntityFilePath))
+            {
+                return heroEntityFilePath;
+            }
+
+            var heroDirectoryPathInfo = new DirectoryInfo(heroDirectoryPath);
+            var heroNameEntityFilePath = Path.Combine(heroDirectoryPath, $"{heroDirectoryPathInfo.Name}.entity");
+
+            if (File.Exists(heroNameEntityFilePath))
+            {
+                return heroNameEntityFilePath;
+            }
+
+            throw new FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
         }
     }
 }

--- a/src/HoNAvatarManager.Core/Parsers/EntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/EntityParser.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using HoNAvatarManager.Core.Extensions;
+using HoNAvatarManager.Core.Helpers;
 
 namespace HoNAvatarManager.Core.Parsers
 {
@@ -25,5 +28,61 @@ namespace HoNAvatarManager.Core.Parsers
         }
 
         public abstract void SetEntity(string heroDirectoryPath, string avatarKey);
+
+        protected string GetAvatarDirectory(string heroDirectoryPath, string avatarKey)
+        {
+            var heroDirectories = Directory.EnumerateDirectories(heroDirectoryPath).Select(d => new DirectoryInfo(d));
+            var avatarDirectory = heroDirectories.FirstOrDefault(d => string.Equals(d.Name, avatarKey, StringComparison.InvariantCultureIgnoreCase));
+
+            if (avatarDirectory != null)
+            {
+                return avatarDirectory.FullName;
+            }
+
+            var parsedAvatarKey = avatarKey.ParseAvatarKey();
+            avatarDirectory = heroDirectories.FirstOrDefault(d => string.Equals(d.Name, parsedAvatarKey, StringComparison.InvariantCultureIgnoreCase));
+
+            if (avatarDirectory != null)
+            {
+                return avatarDirectory.FullName;
+            }
+
+            var entityFilePath = GetHeroEntityPath(heroDirectoryPath);
+            var entityXml = _xmlManager.GetXmlDocument(entityFilePath);
+
+            var entityElement = entityXml.QuerySelector("hero");
+            var entityAvatarElements = entityElement.QuerySelectorAll("altavatar");
+            var entityAvatarElement = entityAvatarElements.FirstOrDefault(a => a.HasKey(avatarKey));
+
+            var modelDirectory = entityAvatarElement.GetAttribute("model").Split("/").First();
+            var avatarDirectoryPath = Path.Combine(heroDirectoryPath, modelDirectory);
+
+            if (Directory.Exists(avatarDirectoryPath))
+            {
+                return avatarDirectoryPath;
+            }
+
+            throw ThrowHelper.DirectoryNotFoundException($"Directory not found for avatar {avatarKey}.");
+        }
+
+        protected string GetHeroEntityPath(string heroDirectoryPath)
+        {
+            var heroEntityFilePath = Path.Combine(heroDirectoryPath, $"hero.entity");
+
+            if (File.Exists(heroEntityFilePath))
+            {
+                return heroEntityFilePath;
+            }
+
+            var heroDirectoryPathInfo = new DirectoryInfo(heroDirectoryPath);
+            var heroNameEntityFilePath = Path.Combine(heroDirectoryPath, $"{heroDirectoryPathInfo.Name}.entity");
+
+            if (File.Exists(heroNameEntityFilePath))
+            {
+                return heroNameEntityFilePath;
+            }
+
+            throw ThrowHelper.FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
+        }
     }
 }

--- a/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using HoNAvatarManager.Core.Extensions;
 
@@ -19,13 +18,28 @@ namespace HoNAvatarManager.Core.Parsers.Hero
 
         protected void SetEntityInternal(string heroDirectoryPath, string avatarKey, string entityName)
         {
-            var entityFilePath = Path.Combine(heroDirectoryPath, $"{entityName}.entity");
+            var heroEntityFilePath = Path.Combine(heroDirectoryPath, $"{entityName}.entity");
 
-            if (!File.Exists(entityFilePath))
+            if (File.Exists(heroEntityFilePath))
             {
+                SetHeroEntity(heroEntityFilePath, avatarKey, entityName);
                 return;
             }
 
+            var heroDirectoryPathInfo = new DirectoryInfo(heroDirectoryPath);
+            var heroNameEntityFilePath = Path.Combine(heroDirectoryPath, $"{heroDirectoryPathInfo.Name}.entity");
+
+            if (File.Exists(heroNameEntityFilePath))
+            {
+                SetHeroEntity(heroNameEntityFilePath, avatarKey, entityName);
+                return;
+            }
+
+            throw new FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
+        }
+
+        protected void SetHeroEntity(string entityFilePath, string avatarKey, string entityName)
+        {
             var entityXml = _xmlManager.GetXmlDocument(entityFilePath);
 
             var entityElement = entityXml.QuerySelector(entityName);

--- a/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
+++ b/src/HoNAvatarManager.Core/Parsers/Hero/HeroEntityParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using HoNAvatarManager.Core.Extensions;
+using HoNAvatarManager.Core.Helpers;
 
 namespace HoNAvatarManager.Core.Parsers.Hero
 {
@@ -35,7 +36,7 @@ namespace HoNAvatarManager.Core.Parsers.Hero
                 return;
             }
 
-            throw new FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
+            throw ThrowHelper.FileNotFoundException("Hero entity file not found.", heroNameEntityFilePath);
         }
 
         protected void SetHeroEntity(string entityFilePath, string avatarKey, string entityName)
@@ -51,7 +52,7 @@ namespace HoNAvatarManager.Core.Parsers.Hero
                 return;
             }
 
-            entityElement.SetElementAttributes(entityAvatarElement).SetElementChilds(entityAvatarElement);
+            entityElement.SetElementAttributes(entityAvatarElement, "announcersound").SetElementChilds(entityAvatarElement);
 
             entityXml.SaveXml(entityFilePath);
         }

--- a/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
+++ b/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
@@ -3163,47 +3163,47 @@
     "avatarInfo": [
       {
         "avatarName": "Sexy Moon Queen",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Sexy"
       },
       {
         "avatarName": "Blood Moon Queen",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.main_reskin"
       },
       {
         "avatarName": "Moon Prince",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt2"
       },
       {
         "avatarName": "Throwback Moon Queen",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Classic"
       },
       {
-        "avatarName": "Eclipse ",
-        "resourceName": ""
+        "avatarName": "Eclipse",
+        "resourceName": "Hero_Krixi.Alt3"
       },
       {
         "avatarName": "POG Moon Queen",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.pog_skin"
       },
       {
         "avatarName": "Lady Liberty",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt4"
       },
       {
         "avatarName": "Gisele",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt5"
       },
       {
         "avatarName": "Nian Guardian Moon Queen",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt7"
       },
       {
         "avatarName": "Lunari",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt8"
       },
       {
         "avatarName": "Moon",
-        "resourceName": ""
+        "resourceName": "Hero_Krixi.Alt9"
       }
     ]
   },

--- a/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
+++ b/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
@@ -3278,59 +3278,59 @@
     "avatarInfo": [
       {
         "avatarName": "Teen Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt"
       },
       {
         "avatarName": "Night Hunter",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt2"
       },
       {
         "avatarName": "Night Hoodlum",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt3"
       },
       {
         "avatarName": "Throwback Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Classic"
       },
       {
         "avatarName": "Cowardly Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt4"
       },
       {
         "avatarName": "POG Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.pog_skin"
       },
       {
         "avatarName": "Rabid Night Bunny",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt5"
       },
       {
         "avatarName": "Leo",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt6"
       },
       {
         "avatarName": "Fright Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt7"
       },
       {
         "avatarName": "Ferocious Leo",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt9"
       },
       {
         "avatarName": "Catnip Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt10"
       },
       {
         "avatarName": "Plushie Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt11"
       },
       {
         "avatarName": "Misfit Night Hound",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt12"
       },
       {
         "avatarName": "Wildcat",
-        "resourceName": ""
+        "resourceName": "Hero_Hantumon.Alt13"
       }
     ]
   },

--- a/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
+++ b/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
@@ -1797,31 +1797,31 @@
       },
       {
         "avatarName": "Trophy Flint Beastwood",
-        "resourceName": "Hero_FlintBeastwood.Alt10"
+        "resourceName": "Hero_FlintBeastwood.trophy_skin"
       },
       {
         "avatarName": "Redcoat Flint",
-        "resourceName": "Hero_FlintBeastwood.Alt11"
+        "resourceName": "Hero_FlintBeastwood.Alt10"
       },
       {
         "avatarName": "Hired Gun Flint",
-        "resourceName": "Hero_FlintBeastwood.Alt12"
+        "resourceName": "Hero_FlintBeastwood.Alt11"
       },
       {
         "avatarName": "Flint Who Stole Xmas",
-        "resourceName": "Hero_FlintBeastwood.Alt13"
+        "resourceName": "Hero_FlintBeastwood.Alt12"
       },
       {
         "avatarName": "Punk Flint",
-        "resourceName": "Hero_FlintBeastwood.Alt14"
+        "resourceName": "Hero_FlintBeastwood.Alt13"
       },
       {
         "avatarName": "F.L.E.X Flint",
-        "resourceName": "Hero_FlintBeastwood.Alt15"
+        "resourceName": "Hero_FlintBeastwood.Alt14"
       },
       {
         "avatarName": "Pill Popper Flint",
-        "resourceName": ""
+        "resourceName": "Hero_FlintBeastwood.Alt15"
       }
     ]
   },

--- a/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
+++ b/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
@@ -3638,11 +3638,11 @@
       },
       {
         "avatarName": "Ellie Envy",
-        "resourceName": "Hero_Parasite.Alt5"
+        "resourceName": "Hero_Parasite.Alt6"
       },
       {
         "avatarName": "Amethyst Paragon Parasite",
-        "resourceName": "Hero_Parasite.Alt6"
+        "resourceName": "Hero_Parasite.Alt5"
       },
       {
         "avatarName": "Trophy Parasite",

--- a/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
+++ b/src/HoNAvatarManager.Core/Resources/avatar_names_mapping.json
@@ -3924,35 +3924,35 @@
     "avatarInfo": [
       {
         "avatarName": "Pollywog Chieftain",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Chieftain"
       },
       {
         "avatarName": "Classic Pollywog Priest",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt2"
       },
       {
         "avatarName": "Holly Polly",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt3"
       },
       {
         "avatarName": "Penguin Priest",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt4"
       },
       {
         "avatarName": "Axolotl Pollywog",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt5"
       },
       {
         "avatarName": "POG Pollywog Priest",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.pog_skin"
       },
       {
         "avatarName": "Prince Polly",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt6"
       },
       {
         "avatarName": "Punk Pollywog",
-        "resourceName": ""
+        "resourceName": "Hero_PollywogPriest.Alt7"
       }
     ]
   },
@@ -5047,71 +5047,67 @@
     "avatarInfo": [
       {
         "avatarName": "Sachi Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt"
       },
       {
         "avatarName": "Ronin Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt2"
       },
       {
         "avatarName": "Bushi Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt3"
       },
       {
-        "avatarName": "Zenifir the Dark Elf ",
-        "resourceName": ""
+        "avatarName": "Zenifir the Dark Elf",
+        "resourceName": "Hero_Hiro.Alt4"
       },
       {
         "avatarName": "Throwback Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Classic"
       },
       {
         "avatarName": "Hunter Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt5"
       },
       {
         "avatarName": "Halion",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt6"
       },
       {
         "avatarName": "Cyber Samurai",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt7"
       },
       {
         "avatarName": "POG Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.pog_skin"
       },
       {
         "avatarName": "Kissaki",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt8"
       },
       {
         "avatarName": "Trophy Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.trophy_skin"
       },
       {
         "avatarName": "Siam Warrior Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt10"
       },
       {
         "avatarName": "Captain of the Royal Guard",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt9"
       },
       {
         "avatarName": "Punk Swifty",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt12"
       },
       {
         "avatarName": "Deathbloom",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt13"
       },
       {
         "avatarName": "Suzaku Swiftblade",
-        "resourceName": ""
-      },
-      {
-        "avatarName": "Suzaku Swiftblade",
-        "resourceName": ""
+        "resourceName": "Hero_Hiro.Alt14"
       }
     ]
   },
@@ -5394,43 +5390,43 @@
     "avatarInfo": [
       {
         "avatarName": "Thor Thunderbringer",
-        "resourceName": ""
-      },
-      {
-        "avatarName": "Lightningbringer",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt"
       },
       {
         "avatarName": "Syrrus the Lightning Caller",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt2"
+      },
+      {
+        "avatarName": "Lightningbringer",
+        "resourceName": "Hero_Kunas.Alt3"
       },
       {
         "avatarName": "Asgard Thor",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt6"
       },
       {
         "avatarName": "Fluffybringer",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt7"
       },
       {
         "avatarName": "POG Thunderbringer",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.pog_skin"
       },
       {
         "avatarName": "The Five Thunder Emperors",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt8"
       },
       {
         "avatarName": "ALPHA Thunderbringer",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt9"
       },
       {
         "avatarName": "Dark Lightninglord",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt10"
       },
       {
         "avatarName": "Raijin",
-        "resourceName": ""
+        "resourceName": "Hero_Kunas.Alt11"
       }
     ]
   },
@@ -5640,35 +5636,35 @@
     "avatarInfo": [
       {
         "avatarName": "Voodoo Raptor",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt"
       },
       {
         "avatarName": "Voodoo Doctor",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt2"
       },
       {
         "avatarName": "Hel",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt3"
       },
       {
         "avatarName": "Ragnarok Hel",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt4"
       },
       {
         "avatarName": "POG Voodoo",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.pog_skin"
       },
       {
         "avatarName": "Siam Warrior Voodoo Jester",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt5"
       },
       {
         "avatarName": "Hunter Voodoo Jester",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt6"
       },
       {
         "avatarName": "Painkiller",
-        "resourceName": ""
+        "resourceName": "Hero_Voodoo.Alt8"
       }
     ]
   },

--- a/src/HoNAvatarManager.Core/ResourcesManager.cs
+++ b/src/HoNAvatarManager.Core/ResourcesManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using HoNAvatarManager.Core.Helpers;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -50,6 +51,8 @@ namespace HoNAvatarManager.Core
 
         private int GetHeroResourcesIndex(string hero)
         {
+            var resourceIndex = -1;
+
             for (int i = 0; i <= 3; i++)
             {
                 var heroes = GetResourcesHeroes(i);
@@ -58,11 +61,17 @@ namespace HoNAvatarManager.Core
 
                 if (!string.IsNullOrEmpty(heroResources))
                 {
-                    return i;
+                    resourceIndex = i;
+                    break;
                 }
             }
 
-            throw new FileNotFoundException($"Resources file for hero {hero} not found.");
+            if (resourceIndex < 0)
+            {
+                throw ThrowHelper.FileNotFoundException($"Resources file for hero {hero} not found.");
+            }
+
+            return resourceIndex;
         }
 
         private IEnumerable<string> GetResourcesHeroes(int resourcesIndex)
@@ -71,7 +80,7 @@ namespace HoNAvatarManager.Core
 
             if (!File.Exists(resourcesPath))
             {
-                throw new FileNotFoundException("Resources file not found", resourcesPath);
+                throw ThrowHelper.FileNotFoundException("Resources file not found.", resourcesPath);
             }
 
             using (var resourcesZip = ZipFile.Open(resourcesPath, ZipArchiveMode.Read))


### PR DESCRIPTION
* Fixed avatars for the following heroes: **Flint Beastwood**, **Moon Queen**, **Night Hound**, **Parasite**, **Pollywog Priest**, **Swiftblade**, **Thunderbringer** and **Voodoo Jester**.
* Added `Create an issue` link for each custom exception.
* Incremented version to 0.1.6.